### PR TITLE
Remove redundant files and modernize packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,21 +6,43 @@ build-backend = "hatchling.build"
 name = "kafka-viz"
 version = "0.1.0"
 description = "Tool for visualizing Kafka microservices architecture"
+readme = "README.md"
+authors = [{name = "Emil Holmegaard"}]
+license = "MIT"
 requires-python = ">=3.8"
 dependencies = [
+    "graphviz>=0.20.1",
     "typer>=0.9.0",
     "rich>=13.7.0",
-    "regex>=2023.12.25"
+    "regex>=2023.12.25",
+    "avro-python3>=1.10.2",
+    "prettytable>=3.9.0",
+    "pyyaml>=6.0"
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0.0",
-    "pytest-cov>=4.0.0",
-    "black>=23.0.0",
-    "isort>=5.0.0",
-    "mypy>=1.0.0"
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+    "black>=22.0",
+    "isort>=5.0",
+    "mypy>=1.0",
+    "flake8>=6.0"
 ]
 
 [project.scripts]
 kafka-viz = "kafka_viz.cli:app"
+
+[tool.black]
+line-length = 88
+target-version = ['py38']
+
+[tool.isort]
+profile = "black"
+line_length = 88
+
+[tool.mypy]
+python_version = "3.8"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true

--- a/src/kafka_viz/analyzers/avro.py
+++ b/src/kafka_viz/analyzers/avro.py
@@ -1,0 +1,16 @@
+from typing import Dict, Any
+import json
+import avro.schema
+from avro.datafile import DataFileReader
+from avro.io import DatumReader
+
+def parse_avro_schema(schema_path: str) -> Dict[str, Any]:
+    """Parse an Avro schema file and return its structure."""
+    with open(schema_path, 'r') as f:
+        schema_json = json.load(f)
+    return avro.schema.parse(json.dumps(schema_json))
+
+def read_avro_data(data_path: str) -> list:
+    """Read data from an Avro file."""
+    reader = DataFileReader(open(data_path, 'rb'), DatumReader())
+    return [record for record in reader]

--- a/src/kafka_viz/analyzers/patterns.py
+++ b/src/kafka_viz/analyzers/patterns.py
@@ -1,0 +1,16 @@
+import re
+from typing import List, Pattern
+
+def get_kafka_patterns() -> List[Pattern]:
+    """Return compiled regex patterns for finding Kafka-related code."""
+    return [
+        re.compile(r'@KafkaListener\(.*?\)'),
+        re.compile(r'@SendTo\(.*?\)'),
+        re.compile(r'KafkaTemplate<.*?>'),
+        re.compile(r'new KafkaConsumer\(.*?\)'),
+        re.compile(r'new KafkaProducer\(.*?\)'),
+        re.compile(r'from kafka import KafkaConsumer, KafkaProducer'),
+        re.compile(r'using Kafka\.Clients'),
+        re.compile(r'kafka\.clients\.consumer'),
+        re.compile(r'kafka\.clients\.producer')
+    ]


### PR DESCRIPTION
This PR removes redundant files and modernizes the Python packaging setup:

1. Removes `/scripts` directory and integrates its functionality into the main package:
   - Moved `kafka_pattern_finder.py` to `src/kafka_viz/analyzers/patterns.py`
   - Moved `parse_avro.py` to `src/kafka_viz/analyzers/avro.py`
   - Other script functionality was already moved to core modules

2. Removes `requirements.txt` in favor of `pyproject.toml`

3. Updates packaging configuration:
   - Uses `pyproject.toml` as the single source of build configuration
   - Adds development dependencies
   - Configures code formatting tools (black, isort)
   - Adds type checking configuration (mypy)

Files to be deleted:
- `/scripts/analyze.py`
- `/scripts/kafka_pattern_finder.py`
- `/scripts/parse_avro.py`
- `/scripts/visualize.py`
- `requirements.txt`
- `setup.py`

The functionality remains the same, but the code is now better organized and follows modern Python packaging practices.