### PR TITLE
Fix dependency conflicts and add version constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,23 +11,31 @@ authors = [{name = "Emil Holmegaard"}]
 license = "MIT"
 requires-python = ">=3.8"
 dependencies = [
-    "graphviz>=0.20.1",
-    "typer>=0.9.0",
-    "rich>=13.7.0",
+    "graphviz>=0.20.1,<1.0",
+    "typer>=0.9.0,<1.0",
+    "rich>=13.7.0,<14.0",
     "regex>=2023.12.25",
-    "avro-python3>=1.10.2",
-    "prettytable>=3.9.0",
-    "pyyaml>=6.0"
+    "avro-python3>=1.10.2,<2.0",
+    "prettytable>=3.9.0,<4.0",
+    "pyyaml>=6.0,<7.0"
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0",
-    "pytest-cov>=4.0",
-    "black>=22.0",
-    "isort>=5.0",
-    "mypy>=1.0",
-    "flake8>=6.0"
+    # Testing
+    "pytest>=7.0,<8.0",
+    "pytest-cov>=4.0,<5.0",
+    
+    # Linting
+    "black>=22.0,<23.0",
+    "isort>=5.0,<6.0",
+    "flake8>=6.0,<7.0",
+    "mccabe>=0.6.0,<0.7.0",  # Explicit dependency to fix conflict
+    
+    # Type checking
+    "mypy>=1.0,<2.0",
+    "types-PyYAML",
+    "types-prettytable"
 ]
 
 [project.scripts]


### PR DESCRIPTION
This PR updates the dependency configuration to fix conflicts and improve compatibility:

1. Added explicit version constraints for all dependencies to prevent conflicts
2. Added explicit mccabe dependency with version constraint (0.6.x) to resolve pylint conflict
3. Added missing type stubs for YAML and prettytable
4. Organized dependencies into logical groups (testing, linting, type checking)

The changes should resolve the dependency conflicts with:
- spyder's PyQt5 requirements
- pylint's mccabe requirement

To install the package with these changes:
1. (Optional) Create a new virtual environment
2. Run `pip install -e ".[dev]"`