### PR TITLE
Fix DTOSchema dataclass field order

### DIFF
--- a/kafka_viz/models/schema.py
+++ b/kafka_viz/models/schema.py
@@ -19,7 +19,10 @@ class AvroSchema(Schema):
 @dataclass
 class DTOSchema(Schema):
     """Represents a DTO class."""
+    name: str
+    file_path: Path
     language: str
+    fields: Dict[str, str] = field(default_factory=dict)
     serialization_format: Optional[str] = None  # 'JSON', 'XML', etc.
     service_name: Optional[str] = None
 


### PR DESCRIPTION
This PR fixes a TypeError in the DTOSchema dataclass by properly ordering the fields. In Python dataclasses, non-default arguments must come before default arguments.

Changes:
1. Reordered DTOSchema fields to put required fields first:
   - name
   - file_path
   - language
   
2. Then optional fields with defaults:
   - fields (with default_factory)
   - serialization_format (defaulting to None)
   - service_name (defaulting to None)

3. Made DTOSchema properly inherit from Schema by explicitly declaring all required fields

The error occurred because we were trying to inherit from Schema but also adding a non-default 'language' field after fields that had defaults.