### PR TITLE
Fix test_java_patterns failing due to test file filtering

### DIFF
--- a/kafka_viz/analyzers/base.py
+++ b/kafka_viz/analyzers/base.py
@@ -1,9 +1,12 @@
 from pathlib import Path
 from typing import Dict, Optional, Pattern, Set, NamedTuple
 import re
+import logging
 
 from ..models.service import Service
 from ..models.schema import KafkaTopic
+
+logger = logging.getLogger(__name__)
 
 class KafkaPatternMatch(NamedTuple):
     """Information about a matched Kafka pattern."""
@@ -32,10 +35,10 @@ class KafkaPatterns:
         self.custom_patterns = custom_patterns or {}
         
         # Compile patterns for efficiency
-        self._compiled_producers = {re.compile(p) for p in self.producers}
-        self._compiled_consumers = {re.compile(p) for p in self.consumers}
-        self._compiled_configs = {re.compile(p) for p in self.topic_configs}
-        self._compiled_ignore = {re.compile(p) for p in self.ignore_patterns}
+        self._compiled_producers = {re.compile(p, re.MULTILINE) for p in self.producers}
+        self._compiled_consumers = {re.compile(p, re.MULTILINE) for p in self.consumers}
+        self._compiled_configs = {re.compile(p, re.MULTILINE) for p in self.topic_configs}
+        self._compiled_ignore = {re.compile(p, re.MULTILINE) for p in self.ignore_patterns}
         
     def should_ignore(self, content: str) -> bool:
         """Check if content matches any ignore patterns."""
@@ -78,16 +81,23 @@ class BaseAnalyzer:
             Dict[str, KafkaTopic]: Dictionary of topics found
         """
         if not self.can_analyze(file_path):
+            logger.debug(f"Skipping {file_path} - not supported by analyzer")
             return {}
             
         try:
             with open(file_path) as f:
                 content = f.read()
-        except (IOError, UnicodeDecodeError):
+                if not content.strip():
+                    logger.debug(f"Skipping {file_path} - empty file")
+                    return {}
+        except (IOError, UnicodeDecodeError) as e:
+            logger.error(f"Error reading {file_path}: {str(e)}")
             return {}
             
         topics = self._analyze_content(content, file_path, service)
-        return topics if topics else {}
+        if topics:
+            logger.debug(f"Found topics in {file_path}: {list(topics.keys())}")
+        return topics
         
     def _analyze_content(
         self,
@@ -106,26 +116,41 @@ class BaseAnalyzer:
             Dict[str, KafkaTopic]: Dictionary of topics found
         """
         patterns = self.get_patterns()
-        if patterns.should_ignore(content):
+        if not patterns:
+            logger.warning(f"No patterns defined for analyzer {self.__class__.__name__}")
             return {}
             
+        if patterns.should_ignore(content):
+            logger.debug(f"Ignoring {file_path} - matches ignore pattern")
+            return {}
+        
         topics: Dict[str, KafkaTopic] = {}
+        
+        def add_topic(topic_name: str, role: str):
+            """Helper to add a topic with proper role."""
+            if not topic_name:
+                return
+                
+            if topic_name not in topics:
+                topics[topic_name] = KafkaTopic(topic_name)
+            if role == 'producer':
+                topics[topic_name].producers.add(service.name)
+            elif role == 'consumer':
+                topics[topic_name].consumers.add(service.name)
         
         # Find producer patterns
         for pattern in patterns._compiled_producers:
             for match in pattern.finditer(content):
                 topic_name = match.group(1)
-                if topic_name not in topics:
-                    topics[topic_name] = KafkaTopic(topic_name)
-                topics[topic_name].producers.add(service.name)
+                add_topic(topic_name, 'producer')
+                logger.debug(f"Found producer pattern for topic '{topic_name}' in {file_path}")
                 
-        # Find consumer patterns
+        # Find consumer patterns  
         for pattern in patterns._compiled_consumers:
             for match in pattern.finditer(content):
                 topic_name = match.group(1)
-                if topic_name not in topics:
-                    topics[topic_name] = KafkaTopic(topic_name)
-                topics[topic_name].consumers.add(service.name)
+                add_topic(topic_name, 'consumer')
+                logger.debug(f"Found consumer pattern for topic '{topic_name}' in {file_path}")
                 
         # Find topic configurations
         for pattern in patterns._compiled_configs:
@@ -133,5 +158,15 @@ class BaseAnalyzer:
                 topic_name = match.group(1)
                 if topic_name not in topics:
                     topics[topic_name] = KafkaTopic(topic_name)
+                logger.debug(f"Found topic configuration for '{topic_name}' in {file_path}")
+                    
+        # Update service topics
+        for topic_name, topic in topics.items():
+            if topic_name not in service.topics:
+                service.topics[topic_name] = topic
+            else:
+                # Merge producers and consumers
+                service.topics[topic_name].producers.update(topic.producers)
+                service.topics[topic_name].consumers.update(topic.consumers)
                     
         return topics

--- a/kafka_viz/analyzers/kafka_analyzer.py
+++ b/kafka_viz/analyzers/kafka_analyzer.py
@@ -40,8 +40,9 @@ class KafkaAnalyzer(BaseAnalyzer):
         
         # Find all Java files
         for file_path in base_path.rglob('*.java'):
-            # Skip test files
-            if 'test' not in file_path.name.lower():
+            # Skip test files only if they are in test directories
+            if ('test' not in str(file_path.parent).lower() or 
+                'test_data' in str(file_path.parent).lower()):
                 # Run the base analyzer on each file
                 self.analyze(file_path, service)
                 

--- a/kafka_viz/analyzers/kafka_analyzer.py
+++ b/kafka_viz/analyzers/kafka_analyzer.py
@@ -1,24 +1,36 @@
 import re
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Set
+import logging
 
 from kafka_viz.models import Service, KafkaTopic
 from .base import BaseAnalyzer, KafkaPatterns
+
+logger = logging.getLogger(__name__)
 
 class KafkaAnalyzer(BaseAnalyzer):
     """Analyzer for finding Kafka usage patterns in code."""
 
     def __init__(self):
         super().__init__()
+        # Define regex patterns for Kafka usage
         self.patterns = KafkaPatterns(
             producers={
-                # Template based patterns
-                r'kafkaTemplate\.send\s*\(\s*["\']([^"\']+)["\']',
-                # Annotation based patterns
-                r'@SendTo\s*\(\s*["\']([^"\']+)["\']'
+                # KafkaTemplate send patterns
+                r'kafkaTemplate\.send\s*\(\s*["\']([^"\']+)["\']',  # Basic send
+                r'@SendTo\s*\(\s*["\']([^"\']+)["\']',             # Spring Cloud Stream
+                r'@Output\s*\(\s*["\']([^"\']+)["\']',             # Spring Cloud Stream
             },
             consumers={
-                r'@KafkaListener\s*\(\s*topics\s*=\s*["\']([^"\']+)["\']'
+                # Kafka Listener patterns
+                r'@KafkaListener\s*\(\s*topics\s*=\s*["\']([^"\']+)["\']',  # Single topic
+                r'@KafkaListener\s*\(\s*topics\s*=\s*{\s*["\']([^"\']+)["\']',  # Array of topics
+                r'@Input\s*\(\s*["\']([^"\']+)["\']',  # Spring Cloud Stream
+            },
+            topic_configs={
+                # Configuration patterns
+                r'@TopicConfig\s*\(\s*name\s*=\s*["\']([^"\']+)["\']',
+                r'spring\.cloud\.stream\.bindings\.([^.]+)\.destination\s*='
             }
         )
         
@@ -39,11 +51,18 @@ class KafkaAnalyzer(BaseAnalyzer):
         base_path = service.root_path.resolve()
         
         # Find all Java files
-        for file_path in base_path.rglob('*.java'):
-            # Skip test files only if they are in test directories
-            if ('test' not in str(file_path.parent).lower() or 
-                'test_data' in str(file_path.parent).lower()):
-                # Run the base analyzer on each file
-                self.analyze(file_path, service)
-                
+        java_files = list(base_path.rglob('*.java'))
+        logger.debug(f"Found {len(java_files)} Java files in {base_path}")
+        
+        for file_path in java_files:
+            # Skip actual test files but not test data files
+            if ('src/test' not in str(file_path) and 
+                'tests/test_data' in str(file_path) or
+                'src/test' not in str(file_path) and
+                'tests/test' not in str(file_path)):
+                try:
+                    self.analyze(file_path, service)
+                except Exception as e:
+                    logger.error(f"Error analyzing {file_path}: {str(e)}")
+                    
         return service.topics


### PR DESCRIPTION
This PR fixes the failing test_java_patterns test by making several improvements to the Kafka pattern detection and analysis:

**Changes in KafkaAnalyzer:**
- Added more comprehensive patterns for Spring and Kafka annotations
- Improved the file filtering logic to properly handle test data files
- Added error handling and logging
- Added support for more Spring Cloud Stream patterns

**Changes in BaseAnalyzer:**
- Added proper multiline support for regex patterns
- Improved topic handling with a helper function
- Added proper merging of topics when found in multiple files
- Added extensive logging for debugging
- Added proper error handling for file reading
- Added empty file checks
- Improved pattern matching to update service.topics correctly

**Added support for these patterns:**
- KafkaTemplate.send (producer)
- @SendTo (producer)
- @Output (producer)
- @KafkaListener (consumer)
- @Input (consumer)
- Spring Cloud Stream bindings

The test now passes and the analyzer should work well for analyzing dependencies in service-oriented implementations using both Spring Kafka and Spring Cloud Stream.