### PR TITLE
feat: add CLI entry point configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ authors = [
 ]
 dynamic = ["dependencies"]
 
+[project.scripts]
+kafka-viz = "kafka_viz.cli:app"
+
 [tool.setuptools]
 packages = ["kafka_viz"]
 


### PR DESCRIPTION
This PR adds the CLI entry point configuration to enable the `kafka-viz` command-line interface.

Changes:
1. Added `[project.scripts]` section to `pyproject.toml`
2. Configured `kafka-viz = "kafka_viz.cli:app"` as the entry point

After this change:
1. Uninstall the current installation:
```bash
pip uninstall kafka-viz
```

2. Reinstall with the updated configuration:
```bash
pip install -e ".[dev]"
```

The `kafka-viz` command should now be available in your PATH.

You can verify the installation with:
```bash
which kafka-viz
kafka-viz --help
```